### PR TITLE
Point to ruby 1.8 shim

### DIFF
--- a/Commands/Autocomplete.tmCommand
+++ b/Commands/Autocomplete.tmCommand
@@ -5,8 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
-# encoding: UTF-8
+	<string>#!/usr/bin/env ruby18 -wKU
 
 # Prevent that input data causes trouble in shell commands
 STDIN.read(nil)

--- a/Commands/Convert to format.tmCommand
+++ b/Commands/Convert to format.tmCommand
@@ -5,8 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
-# encoding: UTF-8
+	<string>#!/usr/bin/env ruby18 -wKU
 
 require 'uri'
 

--- a/Commands/Documentation for Resource.tmCommand
+++ b/Commands/Documentation for Resource.tmCommand
@@ -5,8 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
-# encoding: UTF-8
+	<string>#!/usr/bin/env ruby18 -wKU
 
 require ENV['TM_BUNDLE_SUPPORT']+'/lib/turtle'
 require ENV['TM_SUPPORT_PATH'] + '/lib/exit_codes'

--- a/Commands/Execute SPARQL Query.tmCommand
+++ b/Commands/Execute SPARQL Query.tmCommand
@@ -5,8 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
-# encoding: UTF-8
+	<string>#!/usr/bin/env ruby18 -wKU
 
 require 'net/http'
 require 'uri'

--- a/Commands/Register file extensions.tmCommand
+++ b/Commands/Register file extensions.tmCommand
@@ -5,8 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
-# encoding: UTF-8
+	<string>#!/usr/bin/env ruby18 -wKU
 
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 

--- a/Commands/Remove unused @prefix directives.tmCommand
+++ b/Commands/Remove unused @prefix directives.tmCommand
@@ -5,8 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
-# encoding: UTF-8
+	<string>#!/usr/bin/env ruby18 -wKU
 
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'
 require ENV['TM_SUPPORT_PATH'] + '/lib/escape'

--- a/Commands/Un-comment selection.tmCommand
+++ b/Commands/Un-comment selection.tmCommand
@@ -5,8 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
-# encoding: UTF-8
+	<string>#!/usr/bin/env ruby18 -wKU
 
 if ENV['TM_SELECTION'] =~ /^\d*$/
   # Nothing selected

--- a/Commands/Validate syntax.tmCommand
+++ b/Commands/Validate syntax.tmCommand
@@ -5,8 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveActiveFile</string>
 	<key>command</key>
-	<string>#!/System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/bin/ruby -wKU
-# encoding: UTF-8
+	<string>#!/usr/bin/env ruby18 -wKU
 
 require ENV['TM_SUPPORT_PATH'] + '/lib/textmate'
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui'


### PR DESCRIPTION
This allows the bundle to work under Yosemite, also remove outdated UTF-8 comments. Went ahead and deployed this fix due to a user request, will point back to your canonical repository once pulled back in.