### PR TITLE
Fix grammar for use in embedded scopes.

### DIFF
--- a/Syntaxes/Turtle.tmLanguage
+++ b/Syntaxes/Turtle.tmLanguage
@@ -785,10 +785,6 @@
 		</dict>
 		<key>turtleDoc</key>
 		<dict>
-			<key>begin</key>
-			<string>^</string>
-			<key>end</key>
-			<string>\z</string>
 			<key>name</key>
 			<string>meta.spec.turtleDoc.turtle</string>
 			<key>patterns</key>


### PR DESCRIPTION
This change makes it possible to use the grammar in Markdown code blocks or similar embedded scopes.

Currently the explicit begin and end rules cause the embedded grammar to “shoot over” the end of a code block, messing up the syntax highlighting of everything that follows such a block.

Unfortunately I’m not sure if this change breaks any other features of the grammar (after some – very – superficial testing it looks like everything is still working correctly, though).

See https://github.com/MikeMcQuaid/GitHub-Markdown.tmbundle/blob/1.0.0/Syntaxes/Markdown%20(GitHub).tmLanguage for an example of using embedded scopes. I plan to create a PR for that bundle, adding support for SPARQL support, as soon as this PR gets merged.